### PR TITLE
Spotify facade

### DIFF
--- a/astro/src/components/Music.astro
+++ b/astro/src/components/Music.astro
@@ -9,7 +9,7 @@ const albums = result.result as Album[]
 <div class="flex flex-col justify-center gap-4 md:flex-row">
   {
     albums.map((album) => {
-      return <SpotifyPreview album={album}  />
+      return <SpotifyPreview album={album} />
     })
   }
 </div>

--- a/astro/src/components/Music.astro
+++ b/astro/src/components/Music.astro
@@ -1,7 +1,7 @@
 ---
-import SpotifyPreview from "../components/SpotifyPreview.astro"
 import type { Album } from "../types"
 import { sanityAPI } from "../utils/sanity"
+import SpotifyPreview from "./spotify-preview/SpotifyPreview.astro"
 const result = await sanityAPI("albums")
 const albums = result.result as Album[]
 ---
@@ -9,7 +9,7 @@ const albums = result.result as Album[]
 <div class="flex flex-col justify-center gap-4 md:flex-row">
   {
     albums.map((album) => {
-      return <SpotifyPreview album={album} />
+      return <SpotifyPreview album={album}  />
     })
   }
 </div>

--- a/astro/src/components/RandomSnacksVid.tsx
+++ b/astro/src/components/RandomSnacksVid.tsx
@@ -42,6 +42,7 @@ export function RandomSnacksVid({ snacksVids }: Props) {
         src={`${embedURL}${getYoutubeId(vid().url)}`}
         title="YouTube video player"
         allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+        loading="lazy"
         allowfullscreen
         classList={{
           "opacity-0": isFaded(),

--- a/astro/src/components/spotify-preview/SpotifyButton.tsx
+++ b/astro/src/components/spotify-preview/SpotifyButton.tsx
@@ -1,4 +1,4 @@
-import { createSignal } from "solid-js"
+import { spawn } from "child_process"
 
 /** @todo find a better type to extend */
 interface SpotifyButtonProps {
@@ -8,28 +8,34 @@ interface SpotifyButtonProps {
   className?: string
 }
 
-const SpotifyButton = ({ url, title }: SpotifyButtonProps) => {
-  const [isEmbedVisible, setIsEmbedVisible] = createSignal(false)
+const createSpotifyEmbed = (url: string, title: string) => {
+  const document = window.document
+  const spawningButton = document.getElementById(`spotify-button-${title}`)
+  if (!spawningButton) return
 
+  const embed = document.createElement("iframe")
+
+  embed.src = url
+  embed.title = `${title} Spotify Preview`
+  embed.allowFullscreen = false
+  embed.allow =
+    "autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
+  embed.classList.add("mx-auto", "pt-4")
+  spawningButton.replaceWith(embed)
+}
+
+const SpotifyButton = ({ url, title }: SpotifyButtonProps) => {
   return (
     <>
       <button
-        class={`${
-          isEmbedVisible() ? "hidden" : "block"
-        } mx-auto mb-[70px] mt-4 h-[80px] w-[300px] rounded-xl bg-gradient-to-br from-pink-700 to-purple-700`}
+        id={`spotify-button-${title}`}
+        class={`mx-auto mb-[70px] mt-4 h-[80px] w-[300px] rounded-xl bg-gradient-to-br from-pink-700 to-purple-700 text-lg tracking-widest`}
         onClick={() => {
-          setIsEmbedVisible(true)
+          createSpotifyEmbed(url, title)
         }}
       >
-        Listen
+        LISTEN
       </button>
-      <iframe
-        src={url}
-        title={`${title} Spotify Preview`}
-        allowfullscreen={false}
-        allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
-        class={`${isEmbedVisible() ? "block" : "hidden"} mx-auto pt-4`}
-      ></iframe>
     </>
   )
 }

--- a/astro/src/components/spotify-preview/SpotifyButton.tsx
+++ b/astro/src/components/spotify-preview/SpotifyButton.tsx
@@ -1,0 +1,37 @@
+import { createSignal } from "solid-js"
+
+/** @todo find a better type to extend */
+interface SpotifyButtonProps {
+  url: string
+  title: string
+  /** Classes for the button */
+  className?: string
+}
+
+const SpotifyButton = ({ url, title }: SpotifyButtonProps) => {
+  const [isEmbedVisible, setIsEmbedVisible] = createSignal(false)
+
+  return (
+    <>
+      <button
+        class={`${
+          isEmbedVisible() ? "hidden" : "block"
+        } mx-auto mb-[70px] mt-4 h-[80px] w-[300px] rounded-xl bg-gradient-to-br from-pink-700 to-purple-700`}
+        onClick={() => {
+          setIsEmbedVisible(true)
+        }}
+      >
+        Listen
+      </button>
+      <iframe
+        src={url}
+        title={`${title} Spotify Preview`}
+        allowfullscreen={false}
+        allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
+        class={`${isEmbedVisible() ? "block" : "hidden"} mx-auto pt-4`}
+      ></iframe>
+    </>
+  )
+}
+
+export default SpotifyButton

--- a/astro/src/components/spotify-preview/SpotifyPreview.astro
+++ b/astro/src/components/spotify-preview/SpotifyPreview.astro
@@ -11,7 +11,6 @@ interface Props {
 const { album } = Astro.props
 const embedUrl = generateSpotifyEmbed(album.spotifyLink)
 const builder = sanityImageUrl(album.cover)
-
 ---
 
 <div class="" id={album.title}>

--- a/astro/src/components/spotify-preview/SpotifyPreview.astro
+++ b/astro/src/components/spotify-preview/SpotifyPreview.astro
@@ -1,7 +1,8 @@
 ---
-import type { Album } from "../types"
-import { generateSpotifyEmbed } from "../utils/helpers"
-import { sanityImageUrl } from "../utils/sanity"
+import type { Album } from "../../types"
+import { generateSpotifyEmbed } from "../../utils/helpers"
+import { sanityImageUrl } from "../../utils/sanity"
+import SpotifyButton from "./SpotifyButton.tsx"
 
 interface Props {
   album: Album
@@ -10,6 +11,7 @@ interface Props {
 const { album } = Astro.props
 const embedUrl = generateSpotifyEmbed(album.spotifyLink)
 const builder = sanityImageUrl(album.cover)
+
 ---
 
 <div class="" id={album.title}>
@@ -19,15 +21,10 @@ const builder = sanityImageUrl(album.cover)
       loading="lazy"
       width="450px"
       height="450px"
-      class="mx-auto"
+      class="mx-auto pt-4"
       alt={`${album.title} Cover`}
     />
   </a>
 
-  <iframe
-    src={embedUrl}
-    title={`${album.title} Spotify Preview`}
-    allowfullscreen=""
-    allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
-    class="mx-auto pt-4"></iframe>
+  <SpotifyButton url={embedUrl ?? ""} title={album.title} client:visible />
 </div>

--- a/astro/src/components/spotify-preview/SpotifyPreview.astro
+++ b/astro/src/components/spotify-preview/SpotifyPreview.astro
@@ -25,5 +25,13 @@ const builder = sanityImageUrl(album.cover)
     />
   </a>
 
+  <!-- <iframe -->
+  <!--   src={embedUrl} -->
+  <!--   loading="lazy" -->
+  <!--   title={`${album.title} Spotify Preview`} -->
+  <!--   allowfullscreen={false} -->
+  <!--   allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" -->
+  <!--   class={`mx-auto pt-4`} -->
+  <!-- ></iframe> -->
   <SpotifyButton url={embedUrl ?? ""} title={album.title} client:visible />
 </div>


### PR DESCRIPTION
Sets up a facade for the embedded spotify players. spotify loads a bunch of junky JS, so I'm trying to at least keep that behind a user interaction so it doesn't affect the initial page load.